### PR TITLE
Get rustc version string at rustversion crate build time

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -8,6 +8,7 @@ description = "Conditional compilation according to rustc compiler version"
 repository = "https://github.com/dtolnay/rustversion"
 documentation = "https://docs.rs/rustversion"
 readme = "README.md"
+build = "build.rs"
 
 [lib]
 proc-macro = true

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,18 @@
+use std::env;
+use std::ffi::OsString;
+use std::fs;
+use std::path::Path;
+use std::process::Command;
+
+fn main() {
+    let rustc = env::var_os("RUSTC").unwrap_or_else(|| OsString::from("rustc"));
+    let output = Command::new(rustc)
+        .arg("--version")
+        .output()
+        .expect("Failed to exec rustc");
+
+    let string = String::from_utf8(output.stdout).expect("rustc output not utf8");
+    let dir = env::var_os("OUT_DIR").expect("OUT_DIR not set");
+
+    fs::write(&Path::new(&dir).join("version.txt"), &string).expect("failed to write version.txt")
+}

--- a/src/rustc.rs
+++ b/src/rustc.rs
@@ -1,14 +1,14 @@
 use std::env;
-use std::ffi::OsString;
 use std::fmt::{self, Display};
 use std::io;
-use std::process::Command;
 use std::str::FromStr;
 use std::string::FromUtf8Error;
 
 use crate::date::Date;
 use crate::version::{Channel::*, Version};
 use proc_macro2::Span;
+
+const RUSTC_VERSION: &str = include_str!(concat!(env!("OUT_DIR"), "/version.txt"));
 
 #[derive(Debug)]
 pub enum Error {
@@ -48,16 +48,9 @@ impl From<Error> for syn::Error {
 }
 
 pub fn version() -> Result<Version> {
-    let rustc = env::var_os("RUSTC").unwrap_or_else(|| OsString::from("rustc"));
-    let output = Command::new(rustc)
-        .arg("--version")
-        .output()
-        .map_err(Error::Exec)?;
-    let string = String::from_utf8(output.stdout)?;
-
-    match parse(&string) {
+    match parse(RUSTC_VERSION) {
         Some(version) => Ok(version),
-        None => Err(Error::Parse(string)),
+        None => Err(Error::Parse(RUSTC_VERSION.to_string())),
     }
 }
 


### PR DESCRIPTION
Summary:There's no need to fetch the rustc version at proc-macro
invocation time because its always constant for a given compilation of
the crate. Since Rust doesn't have a stable ABI, the compiler used to
compile rustversion is guaranteed to be the same as the one invoking the
rustversion proc macro.