### PR TITLE
Use `--version --verbose` to get rustc version out of clippy-driver

### DIFF
--- a/build/build.rs
+++ b/build/build.rs
@@ -8,11 +8,17 @@ use std::process::{self, Command};
 
 fn main() {
     let rustc = env::var_os("RUSTC").unwrap_or_else(|| OsString::from("rustc"));
-    let output = match Command::new(&rustc).arg("--version").output() {
+    let output = match Command::new(&rustc)
+        .args(&["--version", "--verbose"])
+        .output()
+    {
         Ok(output) => output,
         Err(e) => {
             let rustc = rustc.to_string_lossy();
-            eprintln!("Error: failed to run `{} --version`: {}", rustc, e);
+            eprintln!(
+                "Error: failed to run `{} --version --verbose`: {}",
+                rustc, e
+            );
             process::exit(1);
         }
     };

--- a/build/rustc.rs
+++ b/build/rustc.rs
@@ -26,8 +26,10 @@ pub struct Date {
 }
 
 pub fn parse(string: &str) -> Option<Version> {
-    let last_line = string.lines().last().unwrap_or(&string);
-    let mut words = last_line.trim().split(' ');
+    let rustc_line = string
+        .lines()
+        .find(|l| l.trim_start().starts_with("rustc "))?;
+    let mut words = rustc_line.trim().split(' ');
 
     if words.next()? != "rustc" {
         return None;

--- a/tests/test_parse.rs
+++ b/tests/test_parse.rs
@@ -56,6 +56,20 @@ fn test_parse() {
             },
         ),
         (
+            "rustc 1.40.0 (73528e339 2019-12-16)
+            binary: rustc
+            commit-hash: 73528e339aae0f17a15ffa49a8ac608f50c6cf14
+            commit-date: 2019-12-16
+            host: x86_64-unknown-linux-gnu
+            release: 1.40.0
+            LLVM version: 9.0",
+            Version {
+                minor: 40,
+                patch: 0,
+                channel: Stable,
+            },
+        ),
+        (
             "rustc 1.36.0-nightly",
             Version {
                 minor: 36,
@@ -79,6 +93,12 @@ fn test_parse() {
     ];
 
     for (string, expected) in cases {
-        assert_eq!(parse(string).unwrap(), *expected);
+        assert_eq!(
+            parse(string).as_ref(),
+            Some(expected),
+            "string {} expected {:#?}",
+            string,
+            expected
+        );
     }
 }


### PR DESCRIPTION
Fixes issue #13