### PR TITLE
Add `rustversion::since_date` and `rustversion::before_date`

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,9 +51,18 @@ rustversion = "1.0"
   —<br>
   True on that nightly and all newer ones.
 
+- <b>`#[rustversion::since_date(2019-01-01)]`</b>
+  —<br>
+  True on all compilers built on or after that date (stable, beta, and nightly).  
+  Dev builds are considered to be built after all dates.
+
 - <b>`#[rustversion::before(`</b><i>version or date</i><b>`)]`</b>
   —<br>
   Negative of *#[rustversion::since(...)]*.
+
+- <b>`#[rustversion::before_date(2019-01-01)]`</b>
+  —<br>
+  Negative of *#[rustversion::since_date(...)]*.
 
 - <b>`#[rustversion::not(`</b><i>selector</i><b>`)]`</b>
   —<br>

--- a/src/bound.rs
+++ b/src/bound.rs
@@ -55,7 +55,7 @@ impl PartialEq<Bound> for Version {
     fn eq(&self, rhs: &Bound) -> bool {
         match rhs {
             Bound::Nightly(date) => match self.channel {
-                Stable | Beta | Dev => false,
+                Stable(_) | Beta(_) | Dev => false,
                 Nightly(nightly) => nightly == *date,
             },
             Bound::Stable(release) => {
@@ -70,7 +70,7 @@ impl PartialOrd<Bound> for Version {
     fn partial_cmp(&self, rhs: &Bound) -> Option<Ordering> {
         match rhs {
             Bound::Nightly(date) => match self.channel {
-                Stable | Beta => Some(Ordering::Less),
+                Stable(_) | Beta(_) => Some(Ordering::Less),
                 Nightly(nightly) => Some(nightly.cmp(date)),
                 Dev => Some(Ordering::Greater),
             },

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -61,9 +61,22 @@
 //!   </p>
 //!
 //! - <p style="margin-left:50px;text-indent:-50px">
+//!   <b><code>#[rustversion::since_date(2019-01-01)]</code></b>
+//!   —<br>
+//!   True on all compilers built on or after that date (stable, beta, and nightly)
+//!   Dev builds are considered to be built after all dates.
+//!   </p>
+//!
+//! - <p style="margin-left:50px;text-indent:-50px">
 //!   <b><code>#[rustversion::before(</code></b><i>version or date</i><b><code>)]</code></b>
 //!   —<br>
 //!   Negative of <i>#[rustversion::since(...)]</i>.
+//!   </p>
+//!
+//! - <p style="margin-left:50px;text-indent:-50px">
+//!   <b><code>#[rustversion::before_date(2019-01-01)]</code></b>
+//!   —<br>
+//!   Negative of <i>#[rustversion::since_date(...)]</i>.
 //!   </p>
 //!
 //! - <p style="margin-left:50px;text-indent:-50px">
@@ -186,8 +199,18 @@ pub fn since(args: TokenStream, input: TokenStream) -> TokenStream {
 }
 
 #[proc_macro_attribute]
+pub fn since_date(args: TokenStream, input: TokenStream) -> TokenStream {
+    cfg("since_date", args, input)
+}
+
+#[proc_macro_attribute]
 pub fn before(args: TokenStream, input: TokenStream) -> TokenStream {
     cfg("before", args, input)
+}
+
+#[proc_macro_attribute]
+pub fn before_date(args: TokenStream, input: TokenStream) -> TokenStream {
+    cfg("before_date", args, input)
 }
 
 #[proc_macro_attribute]

--- a/src/version.rs
+++ b/src/version.rs
@@ -8,9 +8,10 @@ pub struct Version {
 }
 
 #[derive(Copy, Clone, Debug, PartialEq)]
+#[allow(dead_code)] // Only one of these variants is ever constructed per build
 pub enum Channel {
-    Stable,
-    Beta,
+    Stable(Option<Date>),
+    Beta(Option<Date>),
     Nightly(Date),
     Dev,
 }

--- a/tests/test_parse.rs
+++ b/tests/test_parse.rs
@@ -8,7 +8,11 @@ fn test_parse() {
             Version {
                 minor: 0,
                 patch: 0,
-                channel: Stable,
+                channel: Stable(Some(Date {
+                    year: 2015,
+                    month: 5,
+                    day: 13
+                })),
             },
         ),
         (
@@ -16,7 +20,7 @@ fn test_parse() {
             Version {
                 minor: 18,
                 patch: 0,
-                channel: Stable,
+                channel: Stable(None),
             },
         ),
         (
@@ -24,7 +28,11 @@ fn test_parse() {
             Version {
                 minor: 24,
                 patch: 1,
-                channel: Stable,
+                channel: Stable(Some(Date {
+                    year: 2018,
+                    month: 2,
+                    day: 27
+                })),
             },
         ),
         (
@@ -32,7 +40,11 @@ fn test_parse() {
             Version {
                 minor: 35,
                 patch: 0,
-                channel: Beta,
+                channel: Beta(Some(Date {
+                    year: 2019,
+                    month: 4,
+                    day: 27
+                })),
             },
         ),
         (


### PR DESCRIPTION
These selectors work like `since` and `before`, but consider stable and
beta compilers as well. This is useful when working around a compiler
bug, since all versions that include a particular fix can be targeted.

I'm not sure how best to write a test for this