### PR TITLE
Add rustversion::cfg! macro

### DIFF
--- a/build/build.rs
+++ b/build/build.rs
@@ -36,7 +36,7 @@ fn main() {
     };
 
     let version = match rustc::parse(&string) {
-        Some(version) => format!("{:#?}\n", version),
+        Some(version) => version,
         None => {
             eprintln!(
                 "Error: unexpected output from `rustc --version`: {:?}\n\n\
@@ -47,6 +47,12 @@ fn main() {
         }
     };
 
+    if version.minor < 38 {
+        // Prior to 1.38, a #[proc_macro] is not allowed to be named `cfg`.
+        println!("cargo:rustc-cfg=cfg_macro_not_allowed");
+    }
+
+    let version = format!("{:#?}\n", version);
     let out_dir = env::var_os("OUT_DIR").expect("OUT_DIR not set");
     let out_file = Path::new(&out_dir).join("version.rs");
     fs::write(out_file, version).expect("failed to write version.rs");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -227,3 +227,18 @@ pub fn attr(args: TokenStream, input: TokenStream) -> TokenStream {
         .and_then(|args| expand::try_attr(args, input))
         .unwrap_or_else(Error::into_compile_error)
 }
+
+#[cfg(not(cfg_macro_not_allowed))]
+#[proc_macro]
+pub fn cfg(input: TokenStream) -> TokenStream {
+    use proc_macro::{Ident, Span, TokenTree};
+    (|| {
+        let ref mut args = iter::new(input);
+        let expr = expr::parse(args)?;
+        token::parse_end(args)?;
+        let boolean = expr.eval(RUSTVERSION);
+        let ident = Ident::new(&boolean.to_string(), Span::call_site());
+        Ok(TokenStream::from(TokenTree::Ident(ident)))
+    })()
+    .unwrap_or_else(Error::into_compile_error)
+}


### PR DESCRIPTION
A function-like procedural macro named `cfg!` was disallowed prior to Rust 1.38:

```console
error: name `cfg` is reserved in macro namespace
   --> src/lib.rs:233:8
    |
233 | pub fn cfg(input: TokenStream) -> TokenStream {
    |        ^^^
```

but this restriction was lifted by https://github.com/rust-lang/rust/pull/62243 (https://github.com/rust-lang/rust/commit/327450797d460ae011eaaba68fae356117ab883d) and https://github.com/rust-lang/rust/pull/62476.

Usage:

```rust
if rustversion::cfg!(nightly) {
    ...
} else {
    ...
}
```

Closes #7.