### PR TITLE
Rename generated file from version.rs to version.expr

### DIFF
--- a/build/build.rs
+++ b/build/build.rs
@@ -54,6 +54,6 @@ fn main() {
 
     let version = format!("{:#?}\n", version);
     let out_dir = env::var_os("OUT_DIR").expect("OUT_DIR not set");
-    let out_file = Path::new(&out_dir).join("version.rs");
-    fs::write(out_file, version).expect("failed to write version.rs");
+    let out_file = Path::new(&out_dir).join("version.expr");
+    fs::write(out_file, version).expect("failed to write version.expr");
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -182,7 +182,7 @@ use crate::error::Error;
 use crate::version::Version;
 use proc_macro::TokenStream;
 
-const RUSTVERSION: Version = include!(concat!(env!("OUT_DIR"), "/version.rs"));
+const RUSTVERSION: Version = include!(concat!(env!("OUT_DIR"), "/version.expr"));
 
 #[proc_macro_attribute]
 pub fn stable(args: TokenStream, input: TokenStream) -> TokenStream {


### PR DESCRIPTION
This avoids disrupting `find . -name '*.rs' | xargs rustfmt`.

```console
error: expected one of `!` or `::`, found `{`
 --> target/debug/build/rustversion-74a17b343f086e80/out/version.rs:1:25
  |
1 | crate::version::Version {
  |                         ^ expected one of `!` or `::`
```