### PR TITLE
Replace parse return type with ParseResult enum

### DIFF
--- a/build/build.rs
+++ b/build/build.rs
@@ -36,8 +36,8 @@ fn main() {
     };
 
     let version = match rustc::parse(&string) {
-        Some(version) => version,
-        None => {
+        rustc::ParseResult::Success(version) => version,
+        rustc::ParseResult::Unrecognized => {
             eprintln!(
                 "Error: unexpected output from `rustc --version`: {:?}\n\n\
                  Please file an issue in https://github.com/dtolnay/rustversion",

--- a/build/rustc.rs
+++ b/build/rustc.rs
@@ -1,6 +1,11 @@
 use self::Channel::*;
 use std::fmt::{self, Debug};
 
+pub enum ParseResult {
+    Success(Version),
+    Unrecognized,
+}
+
 #[cfg_attr(test, derive(PartialEq))]
 pub struct Version {
     pub minor: u16,
@@ -23,14 +28,18 @@ pub struct Date {
     pub day: u8,
 }
 
-pub fn parse(string: &str) -> Option<Version> {
+pub fn parse(string: &str) -> ParseResult {
     let last_line = string.lines().last().unwrap_or(string);
     let mut words = last_line.trim().split(' ');
 
-    if words.next()? != "rustc" {
-        return None;
+    if words.next() != Some("rustc") {
+        return ParseResult::Unrecognized;
     }
 
+    parse_words(&mut words).map_or(ParseResult::Unrecognized, ParseResult::Success)
+}
+
+fn parse_words(words: &mut dyn Iterator<Item = &str>) -> Option<Version> {
     let mut version_channel = words.next()?.split('-');
     let version = version_channel.next()?;
     let channel = version_channel.next();

--- a/tests/test_parse.rs
+++ b/tests/test_parse.rs
@@ -93,6 +93,9 @@ fn test_parse() {
     ];
 
     for (string, expected) in cases {
-        assert_eq!(parse(string).unwrap(), *expected);
+        match parse(string) {
+            ParseResult::Success(version) => assert_eq!(version, *expected),
+            ParseResult::Unrecognized => panic!("unrecognized: {:?}", string),
+        }
     }
 }


### PR DESCRIPTION
In preparation for fixing #13, which will involve adding a variant that reports a clippy version has been found instead of a rustc version.