### PR TITLE
Pass --rustc argument to clippy driver

### DIFF
--- a/build/build.rs
+++ b/build/build.rs
@@ -14,37 +14,51 @@ use std::process::{self, Command};
 
 fn main() {
     let rustc = env::var_os("RUSTC").unwrap_or_else(|| OsString::from("rustc"));
-    let output = match Command::new(&rustc).arg("--version").output() {
-        Ok(output) => output,
-        Err(e) => {
-            let rustc = rustc.to_string_lossy();
-            eprintln!("Error: failed to run `{} --version`: {}", rustc, e);
-            process::exit(1);
-        }
-    };
 
-    let string = match String::from_utf8(output.stdout) {
-        Ok(string) => string,
-        Err(e) => {
-            let rustc = rustc.to_string_lossy();
-            eprintln!(
-                "Error: failed to parse output of `{} --version`: {}",
-                rustc, e,
-            );
-            process::exit(1);
+    let mut is_clippy_driver = false;
+    let version = loop {
+        let mut command = Command::new(&rustc);
+        if is_clippy_driver {
+            command.arg("--rustc");
         }
-    };
+        command.arg("--version");
 
-    let version = match rustc::parse(&string) {
-        rustc::ParseResult::Success(version) => version,
-        rustc::ParseResult::Unrecognized => {
-            eprintln!(
-                "Error: unexpected output from `rustc --version`: {:?}\n\n\
-                 Please file an issue in https://github.com/dtolnay/rustversion",
-                string
-            );
-            process::exit(1);
-        }
+        let output = match command.output() {
+            Ok(output) => output,
+            Err(e) => {
+                let rustc = rustc.to_string_lossy();
+                eprintln!("Error: failed to run `{} --version`: {}", rustc, e);
+                process::exit(1);
+            }
+        };
+
+        let string = match String::from_utf8(output.stdout) {
+            Ok(string) => string,
+            Err(e) => {
+                let rustc = rustc.to_string_lossy();
+                eprintln!(
+                    "Error: failed to parse output of `{} --version`: {}",
+                    rustc, e,
+                );
+                process::exit(1);
+            }
+        };
+
+        break match rustc::parse(&string) {
+            rustc::ParseResult::Success(version) => version,
+            rustc::ParseResult::OopsClippy if !is_clippy_driver => {
+                is_clippy_driver = true;
+                continue;
+            }
+            rustc::ParseResult::Unrecognized | rustc::ParseResult::OopsClippy => {
+                eprintln!(
+                    "Error: unexpected output from `rustc --version`: {:?}\n\n\
+                    Please file an issue in https://github.com/dtolnay/rustversion",
+                    string
+                );
+                process::exit(1);
+            }
+        };
     };
 
     if version.minor < 38 {

--- a/build/rustc.rs
+++ b/build/rustc.rs
@@ -3,6 +3,7 @@ use std::fmt::{self, Debug};
 
 pub enum ParseResult {
     Success(Version),
+    OopsClippy,
     Unrecognized,
 }
 
@@ -32,8 +33,10 @@ pub fn parse(string: &str) -> ParseResult {
     let last_line = string.lines().last().unwrap_or(string);
     let mut words = last_line.trim().split(' ');
 
-    if words.next() != Some("rustc") {
-        return ParseResult::Unrecognized;
+    match words.next() {
+        Some("rustc") => {}
+        Some(word) if word.starts_with("clippy") => return ParseResult::OopsClippy,
+        Some(_) | None => return ParseResult::Unrecognized,
     }
 
     parse_words(&mut words).map_or(ParseResult::Unrecognized, ParseResult::Success)

--- a/tests/test_parse.rs
+++ b/tests/test_parse.rs
@@ -95,7 +95,9 @@ fn test_parse() {
     for (string, expected) in cases {
         match parse(string) {
             ParseResult::Success(version) => assert_eq!(version, *expected),
-            ParseResult::Unrecognized => panic!("unrecognized: {:?}", string),
+            ParseResult::OopsClippy | ParseResult::Unrecognized => {
+                panic!("unrecognized: {:?}", string);
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes #13.

The `--rustc` flag this uses was added to clippy-driver in https://github.com/rust-lang/rust-clippy/pull/5178.

```console
$ clippy-driver --version
clippy 0.1.64 (c2f428d 2022-07-14)

$ clippy-driver --rustc --version
rustc 1.64.0-nightly (c2f428d2f 2022-07-14)

$ rustc --version
rustc 1.64.0-nightly (c2f428d2f 2022-07-14)
```