### PR TITLE
Fix incorrect path in build.rs causing constant build-script reruns

### DIFF
--- a/build/build.rs
+++ b/build/build.rs
@@ -13,7 +13,7 @@ use std::path::Path;
 use std::process::{self, Command};
 
 fn main() {
-    println!("cargo:rerun-if-changed=build.rs");
+    println!("cargo:rerun-if-changed=build/build.rs");
 
     let rustc = env::var_os("RUSTC").unwrap_or_else(|| OsString::from("rustc"));
 


### PR DESCRIPTION
The recent change in 8250521593dfa58c98ab48e55dbb9b296960cb54 is pointing to a non-existent `build.rs` instead of `build/build.rs` which makes Cargo rerun the build script on every compilation