### PR TITLE
Allow for the `const` keyword to be used in trait impls.

### DIFF
--- a/src/constfn.rs
+++ b/src/constfn.rs
@@ -30,6 +30,14 @@ pub(crate) fn insert_const(input: TokenStream, const_span: Span) -> Result<Token
 
     while let Some(token) = input.next() {
         match token {
+            TokenTree::Ident(ref ident) if ident.to_string() == "impl" => {
+                out.extend(pending);
+                out.extend(iter::once(token));
+                let const_ident = TokenTree::Ident(Ident::new("const", const_span));
+                out.extend(iter::once(const_ident));
+                out.extend(input);
+                return Ok(out);
+            }
             TokenTree::Ident(ref ident) if ident.to_string() == "fn" => {
                 let const_ident = Ident::new("const", const_span);
                 out.extend(iter::once(TokenTree::Ident(const_ident)));
@@ -54,5 +62,5 @@ pub(crate) fn insert_const(input: TokenStream, const_span: Span) -> Result<Token
         }
     }
 
-    Err(Error::new(const_span, "only allowed on a fn item"))
+    Err(Error::new(const_span, "only allowed on an impl or fn item"))
 }

--- a/tests/compiletest.rs
+++ b/tests/compiletest.rs
@@ -5,3 +5,11 @@ fn ui() {
     let t = trybuild::TestCases::new();
     t.compile_fail("tests/ui/*.rs");
 }
+
+#[rustversion::attr(not(nightly), ignore)]
+#[cfg_attr(miri, ignore)]
+#[test]
+fn const_impls() {
+    let t = trybuild::TestCases::new();
+    t.pass("tests/nightly/const_impls.rs");
+}

--- a/tests/nightly/const_impls.rs
+++ b/tests/nightly/const_impls.rs
@@ -1,0 +1,12 @@
+#![feature(const_trait_impl)]
+
+#[rustversion::attr(all(), const_trait)]
+trait _Trait {
+    fn _method() {}
+}
+
+#[rustversion::attr(all(), const)]
+impl _Trait for () {}
+const _: () = <() as _Trait>::_method();
+
+fn main() {}

--- a/tests/ui/const-not-fn.stderr
+++ b/tests/ui/const-not-fn.stderr
@@ -1,4 +1,4 @@
-error: only allowed on a fn item
+error: only allowed on an impl or fn item
  --> tests/ui/const-not-fn.rs:1:28
   |
 1 | #[rustversion::attr(all(), const)]


### PR DESCRIPTION
Allow for the `const` keyword to be used in trait
impls. This can be used to implement const traits
on nightly, for example:

```rust
// this requires a feature gate for now.
#![feature(const_trait_impl)]

#[rustversion::attr(nightly, const_trait)]
trait Foo {
    fn foo() -> u32;
}

#[rustversion::attr(nightly, const)]
// this turns into `impl const Foo for u32`.
impl Foo for u32 {
    fn foo() -> u32 {
        42
    }
}
```