### PR TITLE
rerun if RUSTC changes

### DIFF
--- a/build/build.rs
+++ b/build/build.rs
@@ -14,6 +14,7 @@ use std::process::{self, Command};
 
 fn main() {
     println!("cargo:rerun-if-changed=build/build.rs");
+    println!("cargo:rerun-if-env-changed=RUSTC");
 
     let rustc = env::var_os("RUSTC").unwrap_or_else(|| OsString::from("rustc"));
 


### PR DESCRIPTION
Currently rustversion uses RUSTC to determine which executable to ask for a version. If RUSTC changes, then it is possible that the version information changes as well, so should rerun in that case.