### PR TITLE
Add `msrv` macro

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -201,6 +201,11 @@ pub fn nightly(args: TokenStream, input: TokenStream) -> TokenStream {
 }
 
 #[proc_macro_attribute]
+pub fn msrv(args: TokenStream, input: TokenStream) -> TokenStream {
+    expand::cfg("msrv", args, input)
+}
+
+#[proc_macro_attribute]
 pub fn since(args: TokenStream, input: TokenStream) -> TokenStream {
     expand::cfg("since", args, input)
 }

--- a/tests/test_eval.rs
+++ b/tests/test_eval.rs
@@ -3,6 +3,7 @@
     stable(1.34),
     stable(1.34.0),
     beta,
+    msrv,
     nightly,
     nightly(2020-02-25),
     since(1.34),


### PR DESCRIPTION
With the understanding that this goes against your views in #36, ~this seems to be a minimal implementation of an MSRV-condition macro based on the built-in `CARGO_PKG_RUST_VERSION` env var.~

For what it's worth, I do think this would be a valuable addition to this crate. My use case in particular is guarding trybuild tests to MSRV to ensure stable stderr across new `rustc`s. 

Had to file a draft here as my fork didn't run CI, idk why.