### PR TITLE
fix: use backslash for path on windows

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -183,7 +183,11 @@ use crate::error::Error;
 use crate::version::Version;
 use proc_macro::TokenStream;
 
+#[cfg(not(target_os = "windows"))]
 const RUSTVERSION: Version = include!(concat!(env!("OUT_DIR"), "/version.expr"));
+
+#[cfg(target_os = "windows")]
+const RUSTVERSION: Version = include!(concat!(env!("OUT_DIR"), "\\version.expr"));
 
 #[proc_macro_attribute]
 pub fn stable(args: TokenStream, input: TokenStream) -> TokenStream {


### PR DESCRIPTION
In PR https://github.com/tokio-rs/tokio/pull/6558, I was trying to use `rustversion`.

But it fails the [CI on windows-latest](https://github.com/tokio-rs/tokio/actions/runs/9075609753/job/24936610110) due to the following error.
```
couldn't read \\?\D:\a\tokio\tokio\target\debug\build\rustversion-2d44b26e828f2c8d\out/version.expr: The filename, directory name, or volume label syntax is incorrect. (os error 123)
```

This is because currently the version is loaded from a path with fixed `/` as path separator, but on windows the path separator should be `\`.

In this PR, we will change to use `\` as path separator for windows.

In a separate CI run that uses the commit patched from this PR, the [test](https://github.com/tokio-rs/tokio/actions/runs/9076082929/job/24938083324?pr=6558) passes.