### PR TITLE
Support OUT_DIR located in `\\?\` path on Windows

### DIFF
--- a/build/build.rs
+++ b/build/build.rs
@@ -75,10 +75,16 @@ fn main() {
 
     if version.minor >= 80 {
         println!("cargo:rustc-check-cfg=cfg(cfg_macro_not_allowed)");
+        println!("cargo:rustc-check-cfg=cfg(host_os, values(\"windows\"))");
     }
 
     let version = format!("{:#?}\n", version);
     let out_dir = env::var_os("OUT_DIR").expect("OUT_DIR not set");
     let out_file = Path::new(&out_dir).join("version.expr");
     fs::write(out_file, version).expect("failed to write version.expr");
+
+    let host = env::var_os("HOST").expect("HOST not set");
+    if let Some("windows") = host.to_str().unwrap().split('-').nth(2) {
+        println!("cargo:rustc-cfg=host_os=\"windows\"");
+    }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -183,7 +183,11 @@ use crate::error::Error;
 use crate::version::Version;
 use proc_macro::TokenStream;
 
+#[cfg(not(host_os = "windows"))]
 const RUSTVERSION: Version = include!(concat!(env!("OUT_DIR"), "/version.expr"));
+
+#[cfg(host_os = "windows")]
+const RUSTVERSION: Version = include!(concat!(env!("OUT_DIR"), "\\version.expr"));
 
 #[proc_macro_attribute]
 pub fn stable(args: TokenStream, input: TokenStream) -> TokenStream {


### PR DESCRIPTION
This PR is similar to #50, but determining to use `/` vs `\` based on the **host** OS, not the **target** OS.

From [Maximum Path Length Limitation](https://learn.microsoft.com/en-us/windows/win32/fileio/maximum-file-path-limitation): _File I/O functions in the Windows API convert "/" to "\\" as part of converting the name to an NT-style name, except when using the "\\\\?\\" prefix as detailed in the following sections_. If the OUT_DIR directory for the current build on a Windows host is prefixed with "\\\\?\\", then `include!(concat!(…, "/…"))` does not work:

```console
couldn't read \\?\D:\a\tokio\tokio\target\debug\build\rustversion-2d44b26e828f2c8d\out/version.expr: The filename, directory name, or volume label syntax is incorrect. (os error 123)
```

Rustc or cargo do not have any built-in way to handle including code from OUT_DIR robustly (https://github.com/rust-lang/rust/issues/75075).

Specifically for a procedural macro crate, using `target_os` like in #50 sort of works, but only because Cargo does not support cross-compiling procedural macro crates (it just ignores `--target` if `--package` refers to a macro). But other build systems definitely support cross-compiling proc macros, and would be broken by #50 if `target_os` is Windows but the host is not.

Closes #50.