### PR TITLE
Fix margin of rustdoc <code> tags

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,79 +18,79 @@
 //! # Selectors
 //!
 //! - <p style="margin-left:50px;text-indent:-50px">
-//!   <b><code>#[rustversion::stable]</code></b>
+//!   <b><code style="display:inline">#[rustversion::stable]</code></b>
 //!   —<br>
 //!   True on any stable compiler.
 //!   </p>
 //!
 //! - <p style="margin-left:50px;text-indent:-50px">
-//!   <b><code>#[rustversion::stable(1.34)]</code></b>
+//!   <b><code style="display:inline">#[rustversion::stable(1.34)]</code></b>
 //!   —<br>
 //!   True on exactly the specified stable compiler.
 //!   </p>
 //!
 //! - <p style="margin-left:50px;text-indent:-50px">
-//!   <b><code>#[rustversion::beta]</code></b>
+//!   <b><code style="display:inline">#[rustversion::beta]</code></b>
 //!   —<br>
 //!   True on any beta compiler.
 //!   </p>
 //!
 //! - <p style="margin-left:50px;text-indent:-50px">
-//!   <b><code>#[rustversion::nightly]</code></b>
+//!   <b><code style="display:inline">#[rustversion::nightly]</code></b>
 //!   —<br>
 //!   True on any nightly compiler or dev build.
 //!   </p>
 //!
 //! - <p style="margin-left:50px;text-indent:-50px">
-//!   <b><code>#[rustversion::nightly(2019-01-01)]</code></b>
+//!   <b><code style="display:inline">#[rustversion::nightly(2019-01-01)]</code></b>
 //!   —<br>
 //!   True on exactly one nightly.
 //!   </p>
 //!
 //! - <p style="margin-left:50px;text-indent:-50px">
-//!   <b><code>#[rustversion::since(1.34)]</code></b>
+//!   <b><code style="display:inline">#[rustversion::since(1.34)]</code></b>
 //!   —<br>
 //!   True on that stable release and any later compiler, including beta and
 //!   nightly.
 //!   </p>
 //!
 //! - <p style="margin-left:50px;text-indent:-50px">
-//!   <b><code>#[rustversion::since(2019-01-01)]</code></b>
+//!   <b><code style="display:inline">#[rustversion::since(2019-01-01)]</code></b>
 //!   —<br>
 //!   True on that nightly and all newer ones.
 //!   </p>
 //!
 //! - <p style="margin-left:50px;text-indent:-50px">
-//!   <b><code>#[rustversion::before(</code></b><i>version or date</i><b><code>)]</code></b>
+//!   <b><code style="display:inline">#[rustversion::before(</code></b><i>version or date</i><b><code style="display:inline">)]</code></b>
 //!   —<br>
 //!   Negative of <i>#[rustversion::since(...)]</i>.
 //!   </p>
 //!
 //! - <p style="margin-left:50px;text-indent:-50px">
-//!   <b><code>#[rustversion::not(</code></b><i>selector</i><b><code>)]</code></b>
+//!   <b><code style="display:inline">#[rustversion::not(</code></b><i>selector</i><b><code style="display:inline">)]</code></b>
 //!   —<br>
 //!   Negative of any selector; for example <i>#[rustversion::not(nightly)]</i>.
 //!   </p>
 //!
 //! - <p style="margin-left:50px;text-indent:-50px">
-//!   <b><code>#[rustversion::any(</code></b><i>selectors...</i><b><code>)]</code></b>
+//!   <b><code style="display:inline">#[rustversion::any(</code></b><i>selectors...</i><b><code style="display:inline">)]</code></b>
 //!   —<br>
 //!   True if any of the comma-separated selectors is true; for example
 //!   <i>#[rustversion::any(stable, beta)]</i>.
 //!   </p>
 //!
 //! - <p style="margin-left:50px;text-indent:-50px">
-//!   <b><code>#[rustversion::all(</code></b><i>selectors...</i><b><code>)]</code></b>
+//!   <b><code style="display:inline">#[rustversion::all(</code></b><i>selectors...</i><b><code style="display:inline">)]</code></b>
 //!   —<br>
 //!   True if all of the comma-separated selectors are true; for example
 //!   <i>#[rustversion::all(since(1.31), before(1.34))]</i>.
 //!   </p>
 //!
 //! - <p style="margin-left:50px;text-indent:-50px">
-//!   <b><code>#[rustversion::attr(</code></b><i>selector</i><b><code>, </code></b><i>attribute</i><b><code>)]</code></b>
+//!   <b><code style="display:inline">#[rustversion::attr(</code></b><i>selector</i><b><code style="display:inline">, </code></b><i>attribute</i><b><code style="display:inline">)]</code></b>
 //!   —<br>
 //!   For conditional inclusion of attributes; analogous to
-//!   <code>cfg_attr</code>.
+//!   <code style="display:inline">cfg_attr</code>.
 //!   </p>
 //!
 //! <br>


### PR DESCRIPTION
This reverses the effect of https://github.com/rust-lang/rust/pull/132183.

**Before https://github.com/rust-lang/rust/pull/132183:**

<p align="center"><img src="https://github.com/user-attachments/assets/495befa4-0580-4ea5-a505-e00ff6189f12" width="500"></p>

**After https://github.com/rust-lang/rust/pull/132183:**

<p align="center"><img src="https://github.com/user-attachments/assets/462ad047-140b-45d4-af2d-514523f8d92b" width="500"></p>