### PR TITLE
Add -Zfmt-debug=none test in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,9 @@ jobs:
         run: echo RUSTFLAGS=${RUSTFLAGS}\ -Zrandomize-layout >> $GITHUB_ENV
         if: matrix.rust == 'nightly'
       - run: cargo test
+      - name: RUSTFLAGS=-Zfmt-debug=none cargo test
+        run: RUSTFLAGS=${RUSTFLAGS}\ -Zfmt-debug=none cargo test
+        if: matrix.rust == 'nightly'
       - uses: actions/upload-artifact@v4
         if: matrix.rust == 'nightly' && always()
         with:


### PR DESCRIPTION
Prior to #61, this would fail.

```console
error: expected expression, found `<eof>`
 --> /home/runner/work/rustversion/rustversion/target/debug/build/rustversion-3dc54cd5d21b9264/out/version.expr:1:2
  |
1 |
  | ^ expected expression
error: non-expression macro in expression position: include
   --> src/lib.rs:217:30
    |
217 | const RUSTVERSION: Version = include!(concat!(env!("OUT_DIR"), "/version.expr"));
    |                              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
error: could not compile `rustversion` (lib) due to 2 previous errors
```